### PR TITLE
NodeComponent EndPlay crash fix

### DIFF
--- a/Source/NodeJs/Private/NodeComponent.cpp
+++ b/Source/NodeJs/Private/NodeComponent.cpp
@@ -47,6 +47,7 @@ void UNodeComponent::BeginPlay()
 
 void UNodeComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
+	Super::EndPlay(EndPlayReason);
 	Cmd->bShouldStopMainScriptOnNoListeners = bStopMainScriptOnNoListeners;
 	if (bScriptIsRunning)
 	{

--- a/Source/NodeJs/Private/NodeComponent.cpp
+++ b/Source/NodeJs/Private/NodeComponent.cpp
@@ -47,7 +47,6 @@ void UNodeComponent::BeginPlay()
 
 void UNodeComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
-	Super::EndPlay(EndPlayReason);
 	Cmd->bShouldStopMainScriptOnNoListeners = bStopMainScriptOnNoListeners;
 	if (bScriptIsRunning)
 	{
@@ -59,6 +58,7 @@ void UNodeComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	}
 
 	Cmd->RemoveEventListener(Listener);
+	Super::EndPlay(EndPlayReason);
 }
 
 void UNodeComponent::LinkAndStartWrapperScript()


### PR DESCRIPTION
Added  `Super::EndPlay(EndPlayReason);` to NodeComponent, because it crashes in the latest version of Unreal otherwise.